### PR TITLE
fix further findings, make RemoteService options dynamic

### DIFF
--- a/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/ConnectedDriveConstants.java
+++ b/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/ConnectedDriveConstants.java
@@ -34,6 +34,7 @@ public class ConnectedDriveConstants {
     public static final String UNITS_IMPERIAL = "IMPERIAL";
     public static final String UNITS_METRIC = "METRIC";
 
+    public static final String CONFIG_VIN = "vin";
     public static final int DEFAULT_IMAGE_SIZE = 1024;
     public static final int DEFAULT_REFRESH_INTERVAL = 5;
     public static final String DEFAULT_IMAGE_VIEWPORT = "FRONT";

--- a/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/discovery/VehicleDiscovery.java
+++ b/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/discovery/VehicleDiscovery.java
@@ -12,6 +12,7 @@
  */
 package org.openhab.binding.bmwconnecteddrive.internal.discovery;
 
+import static org.openhab.binding.bmwconnecteddrive.internal.ConnectedDriveConstants.CONFIG_VIN;
 import static org.openhab.binding.bmwconnecteddrive.internal.ConnectedDriveConstants.SUPPORTED_THING_SET;
 
 import java.lang.reflect.Field;
@@ -108,8 +109,8 @@ public class VehicleDiscovery extends AbstractDiscoveryService implements Discov
                         final AtomicBoolean foundVehicle = new AtomicBoolean(false);
                         bridge.getThing().getThings().forEach(vehicleThing -> {
                             Configuration c = vehicleThing.getConfiguration();
-                            if (c.containsKey("vin")) {
-                                String thingVIN = c.get("vin").toString();
+                            if (c.containsKey(CONFIG_VIN)) {
+                                String thingVIN = c.get(CONFIG_VIN).toString();
                                 if (vehicle.vin.equals(thingVIN)) {
                                     vehicleThing.setProperties(properties);
                                     foundVehicle.set(true);
@@ -120,7 +121,7 @@ public class VehicleDiscovery extends AbstractDiscoveryService implements Discov
                         // Vehicle not found -> trigger discovery
                         if (!foundVehicle.get()) {
                             // Properties needed for functional THing
-                            properties.put("vin", vehicle.vin);
+                            properties.put(CONFIG_VIN, vehicle.vin);
                             properties.put("refreshInterval",
                                     Integer.toString(ConnectedDriveConstants.DEFAULT_REFRESH_INTERVAL));
                             properties.put("units", ConnectedDriveConstants.UNITS_AUTODETECT);
@@ -130,7 +131,7 @@ public class VehicleDiscovery extends AbstractDiscoveryService implements Discov
                             String vehicleLabel = vehicle.brand + " " + vehicle.model;
                             Map<String, Object> convertedProperties = new HashMap<String, Object>(properties);
                             thingDiscovered(DiscoveryResultBuilder.create(uid).withBridge(bridgeUID)
-                                    .withRepresentationProperty("vin").withLabel(vehicleLabel)
+                                    .withRepresentationProperty(CONFIG_VIN).withLabel(vehicleLabel)
                                     .withProperties(convertedProperties).build());
                         }
                     }

--- a/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/dto/Destination.java
+++ b/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/dto/Destination.java
@@ -14,7 +14,6 @@ package org.openhab.binding.bmwconnecteddrive.internal.dto;
 
 import static org.openhab.binding.bmwconnecteddrive.internal.utils.Constants.*;
 
-import org.openhab.binding.bmwconnecteddrive.internal.utils.Constants;
 import org.openhab.binding.bmwconnecteddrive.internal.utils.Converter;
 
 /**
@@ -32,38 +31,25 @@ public class Destination {
     public String type;
     public String createdAt;
 
-    private String address = null;
-    private String coordinates = null;
-
     public String getAddress() {
-        if (address == null) {
-            StringBuilder buf = new StringBuilder();
-            if (street != null) {
-                buf.append(street);
-                if (streetNumber != null) {
-                    buf.append(SPACE).append(streetNumber);
-                }
-            }
-            if (city != null) {
-                if (buf.length() > 0) {
-                    buf.append(COMMA).append(SPACE).append(city);
-                } else {
-                    buf.append(city);
-                }
-            }
-            if (buf.length() == 0) {
-                address = UNDEF;
-            } else {
-                address = Converter.toTitleCase(buf.toString());
+        final StringBuilder buf = new StringBuilder();
+        if (street != null) {
+            buf.append(street);
+            if (streetNumber != null) {
+                buf.append(SPACE).append(streetNumber);
             }
         }
-        return address;
+        if (city != null) {
+            if (buf.length() > 0) {
+                buf.append(COMMA).append(SPACE).append(city);
+            } else {
+                buf.append(city);
+            }
+        }
+        return buf.length() == 0 ? UNDEF : Converter.toTitleCase(buf.toString());
     }
 
     public String getCoordinates() {
-        if (coordinates == null) {
-            coordinates = new StringBuilder().append(lat).append(Constants.COMMA).append(lon).toString();
-        }
-        return coordinates;
+        return Float.toString(lat) + COMMA + lon;
     }
 }

--- a/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/dto/status/Position.java
+++ b/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/dto/status/Position.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.binding.bmwconnecteddrive.internal.dto.status;
 
-import org.openhab.binding.bmwconnecteddrive.internal.utils.Constants;
+import static org.openhab.binding.bmwconnecteddrive.internal.utils.Constants.COMMA;
 
 /**
  * The {@link Position} Data Transfer Object
@@ -26,11 +26,11 @@ public class Position {
     public String status;// ": "OK"
 
     public String getCoordinates() {
-        return new StringBuilder(Float.toString(lat)).append(Constants.COMMA).append(Float.toString(lon)).toString();
+        return Float.toString(lat) + COMMA + lon;
     }
 
     @Override
     public String toString() {
-        return new StringBuilder(Float.toString(lat)).append(Constants.COMMA).append(Float.toString(lon)).toString();
+        return getCoordinates();
     }
 }

--- a/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/handler/ConnectedDriveBridgeHandler.java
+++ b/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/handler/ConnectedDriveBridgeHandler.java
@@ -93,30 +93,33 @@ public class ConnectedDriveBridgeHandler extends BaseBridgeHandler implements St
 
     public String getDiscoveryFingerprint() {
         return troubleshootFingerprint.map(fingerprint -> {
-            VehiclesContainer container = Converter.getGson().fromJson(fingerprint, VehiclesContainer.class);
-            if (container != null) {
-                if (container.vehicles != null) {
-                    if (container.vehicles.isEmpty()) {
-                        return Constants.EMPTY_VEHICLES;
-                    } else {
-                        container.vehicles.forEach(entry -> {
-                            entry.vin = ANONYMOUS;
-                            entry.breakdownNumber = ANONYMOUS;
-                            if (entry.dealer != null) {
-                                Dealer d = entry.dealer;
-                                d.city = ANONYMOUS;
-                                d.country = ANONYMOUS;
-                                d.name = ANONYMOUS;
-                                d.phone = ANONYMOUS;
-                                d.postalCode = ANONYMOUS;
-                                d.street = ANONYMOUS;
-                            }
-                        });
-                        return Converter.getGson().toJson(container);
+            try {
+                VehiclesContainer container = Converter.getGson().fromJson(fingerprint, VehiclesContainer.class);
+                if (container != null) {
+                    if (container.vehicles != null) {
+                        if (container.vehicles.isEmpty()) {
+                            return Constants.EMPTY_VEHICLES;
+                        } else {
+                            container.vehicles.forEach(entry -> {
+                                entry.vin = ANONYMOUS;
+                                entry.breakdownNumber = ANONYMOUS;
+                                if (entry.dealer != null) {
+                                    Dealer d = entry.dealer;
+                                    d.city = ANONYMOUS;
+                                    d.country = ANONYMOUS;
+                                    d.name = ANONYMOUS;
+                                    d.phone = ANONYMOUS;
+                                    d.postalCode = ANONYMOUS;
+                                    d.street = ANONYMOUS;
+                                }
+                            });
+                            return Converter.getGson().toJson(container);
+                        }
                     }
                 }
+                // Not a VehiclesContainer or Vehicles is empty so deliver fingerprint as it is
+            } catch (JsonSyntaxException e) {
             }
-            // Not a VehiclesContainer or Vehicles is empty so deliver fingerprint as it is
             return fingerprint;
         }).orElse(Constants.INVALID);
     }

--- a/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/handler/RemoteServiceHandler.java
+++ b/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/handler/RemoteServiceHandler.java
@@ -12,6 +12,8 @@
  */
 package org.openhab.binding.bmwconnecteddrive.internal.handler;
 
+import static org.openhab.binding.bmwconnecteddrive.internal.ConnectedDriveConstants.*;
+
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -58,24 +60,29 @@ public class RemoteServiceHandler implements StringResponseCallback {
     }
 
     public enum RemoteService {
-        LIGHT_FLASH("LIGHT_FLASH"),
-        VEHICLE_FINDER("VEHICLE_FINDER"),
-        DOOR_LOCK("DOOR_LOCK"),
-        DOOR_UNLOCK("DOOR_UNLOCK"),
-        HORN("HORN_BLOW"),
-        AIR_CONDITIONING("CLIMATE_NOW"),
-        CHARGE_NOW("CHARGE_NOW"),
-        CHARGING_CONTROL("CHARGING_CONTROL");
+        LIGHT_FLASH(REMOTE_SERVICE_LIGHT_FLASH, "Flash Lights"),
+        VEHICLE_FINDER(REMOTE_SERVICE_VEHICLE_FINDER, "Vehicle Finder"),
+        DOOR_LOCK(REMOTE_SERVICE_DOOR_LOCK, "Door Lock"),
+        DOOR_UNLOCK(REMOTE_SERVICE_DOOR_UNLOCK, "Door Unlock"),
+        HORN_BLOW(REMOTE_SERVICE_HORN, "Horn Blow"),
+        CLIMATE_NOW(REMOTE_SERVICE_AIR_CONDITIONING, "Climate Control"),
+        CHARGE_NOW(REMOTE_SERVICE_CHARGE_NOW, "Start Charging"),
+        CHARGING_CONTROL(REMOTE_SERVICE_CHARGING_CONTROL, "Send Charging Profile");
 
-        private final String service;
+        private final String command;
+        private final String label;
 
-        RemoteService(String s) {
-            service = s;
+        RemoteService(final String command, final String label) {
+            this.command = command;
+            this.label = label;
         }
 
-        @Override
-        public String toString() {
-            return service;
+        public String getCommand() {
+            return command;
+        }
+
+        public String getLabel() {
+            return label;
         }
     }
 
@@ -106,10 +113,10 @@ public class RemoteServiceHandler implements StringResponseCallback {
                 // only one service executing
                 return false;
             }
-            serviceExecuting = Optional.of(service.toString());
+            serviceExecuting = Optional.of(service.name());
         }
         final MultiMap<String> dataMap = new MultiMap<String>();
-        dataMap.add(SERVICE_TYPE, service.toString());
+        dataMap.add(SERVICE_TYPE, service.name());
         if (data.length > 0) {
             dataMap.add(DATA, data[0]);
         }

--- a/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/handler/VehicleChannelHandler.java
+++ b/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/handler/VehicleChannelHandler.java
@@ -43,6 +43,7 @@ import org.openhab.binding.bmwconnecteddrive.internal.utils.ChargeProfileWrapper
 import org.openhab.binding.bmwconnecteddrive.internal.utils.ChargeProfileWrapper.ProfileKey;
 import org.openhab.binding.bmwconnecteddrive.internal.utils.Constants;
 import org.openhab.binding.bmwconnecteddrive.internal.utils.Converter;
+import org.openhab.binding.bmwconnecteddrive.internal.utils.RemoteServiceUtils;
 import org.openhab.binding.bmwconnecteddrive.internal.utils.VehicleStatusUtils;
 import org.openhab.core.library.types.DateTimeType;
 import org.openhab.core.library.types.DecimalType;
@@ -108,6 +109,8 @@ public class VehicleChannelHandler extends BaseThingHandler {
         isElectric = type.equals(VehicleType.PLUGIN_HYBRID.toString())
                 || type.equals(VehicleType.ELECTRIC_REX.toString()) || type.equals(VehicleType.ELECTRIC.toString());
         isHybrid = hasFuel && isElectric;
+
+        setOptions(CHANNEL_GROUP_REMOTE, REMOTE_SERVICE_COMMAND, RemoteServiceUtils.getOptions(isElectric));
     }
 
     @Override

--- a/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/handler/VehicleHandler.java
+++ b/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/handler/VehicleHandler.java
@@ -46,6 +46,7 @@ import org.openhab.binding.bmwconnecteddrive.internal.utils.ChargeProfileWrapper
 import org.openhab.binding.bmwconnecteddrive.internal.utils.Constants;
 import org.openhab.binding.bmwconnecteddrive.internal.utils.Converter;
 import org.openhab.binding.bmwconnecteddrive.internal.utils.ImageProperties;
+import org.openhab.binding.bmwconnecteddrive.internal.utils.RemoteServiceUtils;
 import org.openhab.core.io.net.http.HttpUtil;
 import org.openhab.core.library.types.DecimalType;
 import org.openhab.core.library.types.OnOffType;
@@ -127,25 +128,16 @@ public class VehicleHandler extends VehicleChannelHandler {
                 remote.ifPresent(remot -> {
                     switch (serviceCommand) {
                         case REMOTE_SERVICE_LIGHT_FLASH:
-                            remot.execute(RemoteService.LIGHT_FLASH);
-                            break;
                         case REMOTE_SERVICE_AIR_CONDITIONING:
-                            remot.execute(RemoteService.AIR_CONDITIONING);
-                            break;
                         case REMOTE_SERVICE_DOOR_LOCK:
-                            remot.execute(RemoteService.DOOR_LOCK);
-                            break;
                         case REMOTE_SERVICE_DOOR_UNLOCK:
-                            remot.execute(RemoteService.DOOR_UNLOCK);
-                            break;
                         case REMOTE_SERVICE_HORN:
-                            remot.execute(RemoteService.HORN);
-                            break;
                         case REMOTE_SERVICE_VEHICLE_FINDER:
-                            remot.execute(RemoteService.VEHICLE_FINDER);
-                            break;
                         case REMOTE_SERVICE_CHARGE_NOW:
-                            remot.execute(RemoteService.CHARGE_NOW);
+                            RemoteServiceUtils.getRemoteService(serviceCommand)
+                                    .ifPresentOrElse(service -> remot.execute(service), () -> {
+                                        logger.info("Remote service execution {} unknown", serviceCommand);
+                                    });
                             break;
                         case REMOTE_SERVICE_CHARGING_CONTROL:
                             sendChargeProfile(chargeProfileEdit);

--- a/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/utils/RemoteServiceUtils.java
+++ b/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/utils/RemoteServiceUtils.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.bmwconnecteddrive.internal.utils;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.bmwconnecteddrive.internal.handler.RemoteServiceHandler.RemoteService;
+import org.openhab.core.types.StateOption;
+
+/**
+ * Helper class for Remote Service Commands
+ * 
+ * @author Norbert Truchsess - edit & send of charge profile
+ */
+@NonNullByDefault
+public class RemoteServiceUtils {
+
+    private static final Map<String, RemoteService> CommandService = Stream.of(RemoteService.values())
+            .collect(Collectors.toUnmodifiableMap(RemoteService::getCommand, service -> service));
+
+    private static final Set<RemoteService> ElectricServices = EnumSet.of(RemoteService.CHARGE_NOW,
+            RemoteService.CHARGING_CONTROL);
+
+    public static Optional<RemoteService> getRemoteService(final String command) {
+        return Optional.ofNullable(CommandService.get(command));
+    }
+
+    public static List<StateOption> getOptions(final boolean isElectric) {
+        return Stream.of(RemoteService.values())
+                .filter(service -> isElectric ? true : !ElectricServices.contains(service))
+                .map(service -> new StateOption(service.getCommand(), service.getLabel()))
+                .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/bundles/org.openhab.binding.bmwconnecteddrive/src/main/resources/OH-INF/thing/remote-services-channel-types.xml
+++ b/bundles/org.openhab.binding.bmwconnecteddrive/src/main/resources/OH-INF/thing/remote-services-channel-types.xml
@@ -6,18 +6,6 @@
 	<channel-type id="remote-command-channel">
 		<item-type>String</item-type>
 		<label>Remote Command</label>
-		<command>
-			<options>
-				<option value="light">Flash Lights</option>
-				<option value="finder">Vehicle Finder</option>
-				<option value="lock">Door Lock</option>
-				<option value="unlock">Door Unlock</option>
-				<option value="horn">Horn Blow</option>
-				<option value="climate">Climate Control</option>
-				<option value="charge-now">Start Charging</option>
-				<option value="charge-control">Send Charging Profile</option>
-			</options>
-		</command>
 	</channel-type>
 	<channel-type id="remote-state-channel">
 		<item-type>String</item-type>


### PR DESCRIPTION
ok, second try based on your latest bmw-connected-drive branch.

- fixed open findings from @cpmeister
- made the RemoteService command options dynamic. Non-electric vehicles do not understand chargeprofile