### PR TITLE
fix compile error method 'setThingStatus' being unknown

### DIFF
--- a/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/handler/VehicleHandler.java
+++ b/bundles/org.openhab.binding.bmwconnecteddrive/src/main/java/org/openhab/binding/bmwconnecteddrive/internal/handler/VehicleHandler.java
@@ -645,7 +645,7 @@ public class VehicleHandler extends VehicleChannelHandler {
                 proxy.get().requestLegacyVehcileStatus(configuration.get(), oldVehicleStatusCallback);
             }
             vehicleStatusCache = Optional.of(Converter.getGson().toJson(error));
-            setThingStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, error.reason);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, error.reason);
             removeCallback(this);
         }
     }


### PR DESCRIPTION
a mvn clean install result in a compile-error method 'setThingStatus' being unknown.